### PR TITLE
Minimize consume of KV read, write & delete operation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,12 +33,19 @@ const RATE_LIMIT = {
   WINDOW_MINUTES: 10
 }
 
+// In-memory cache
+let statsCache: StatsData | null = null
+let rateLimitCache: { [key: string]: RateLimitData } = {}
+
 // Middleware
 app.use('*', logger())
 app.use('*', cors())
 
 // Initialize stats if not exists
 async function initializeStats(c: Context<Bindings>): Promise<StatsData> {
+  if (statsCache) {
+    return statsCache
+  }
   const stats = await c.env.STATS_STORE.get('global_stats')
   if (!stats) {
     const initialStats: StatsData = {
@@ -51,9 +58,11 @@ async function initializeStats(c: Context<Bindings>): Promise<StatsData> {
       lastReset: Date.now()
     }
     await c.env.STATS_STORE.put('global_stats', JSON.stringify(initialStats))
+    statsCache = initialStats
     return initialStats
   }
-  return JSON.parse(stats)
+  statsCache = JSON.parse(stats)
+  return statsCache
 }
 
 // Stats middleware
@@ -61,10 +70,17 @@ app.use('*', async (c, next) => {
   if (c.req.method === 'POST' && c.req.path === '/check') {
     const stats = await initializeStats(c)
     stats.totalRequests++
-    await c.env.STATS_STORE.put('global_stats', JSON.stringify(stats))
+    statsCache = stats
   }
   await next()
 })
+
+// Periodically write stats to KV store
+setInterval(async () => {
+  if (statsCache) {
+    await c.env.STATS_STORE.put('global_stats', JSON.stringify(statsCache))
+  }
+}, 60000) // Every 60 seconds
 
 // Rate limiting middleware
 async function checkRateLimit(c: Context<Bindings>, ip: string, domainCount: number): Promise<{ allowed: boolean, remaining: number, resetTime?: Date }> {
@@ -72,14 +88,14 @@ async function checkRateLimit(c: Context<Bindings>, ip: string, domainCount: num
   const now = Date.now()
   const windowStart = now - (RATE_LIMIT.WINDOW_MINUTES * 60 * 1000)
 
-  const stored = await c.env.RATE_LIMIT_STORE.get(key)
-  let usage: RateLimitData | null = stored ? JSON.parse(stored) : null
+  let usage: RateLimitData | null = rateLimitCache[key] || null
   
   if (!usage || usage.timestamp < windowStart) {
     usage = {
       count: domainCount,
       timestamp: now
     }
+    rateLimitCache[key] = usage
     await c.env.RATE_LIMIT_STORE.put(key, JSON.stringify(usage), {
       expirationTtl: RATE_LIMIT.WINDOW_MINUTES * 60 // TTL in seconds
     })
@@ -104,6 +120,7 @@ async function checkRateLimit(c: Context<Bindings>, ip: string, domainCount: num
     count: totalCount,
     timestamp: usage.timestamp
   }
+  rateLimitCache[key] = usage
   await c.env.RATE_LIMIT_STORE.put(key, JSON.stringify(usage), {
     expirationTtl: RATE_LIMIT.WINDOW_MINUTES * 60 // TTL in seconds
   })
@@ -554,7 +571,7 @@ app.post('/check', async (c: Context<Bindings>) => {
     })
 
     // Save updated stats
-    await c.env.STATS_STORE.put('global_stats', JSON.stringify(stats))
+    statsCache = stats
 
     return c.json({
       domains: results,

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,11 +76,12 @@ app.use('*', async (c, next) => {
 })
 
 // Periodically write stats to KV store
-setInterval(async () => {
+app.get('/stats/update', async (c) => {
   if (statsCache) {
     await c.env.STATS_STORE.put('global_stats', JSON.stringify(statsCache))
   }
-}, 60000) // Every 60 seconds
+  return c.json({ message: 'Stats updated' })
+})
 
 // Rate limiting middleware
 async function checkRateLimit(c: Context<Bindings>, ip: string, domainCount: number): Promise<{ allowed: boolean, remaining: number, resetTime?: Date }> {
@@ -286,6 +287,15 @@ const statsHtml = `<!DOCTYPE html>
         // Load stats immediately and refresh every 30 seconds
         loadStats();
         setInterval(loadStats, 30000);
+
+        // Periodically update stats on the server
+        setInterval(async () => {
+            try {
+                await fetch('/stats/update');
+            } catch (error) {
+                console.error('Error updating stats:', error);
+            }
+        }, 60000); // Every 60 seconds
     </script>
 </body>
 </html>`


### PR DESCRIPTION
Fixes #1

Minimize KV read, write, and delete operation consumption to make it more suitable for the free plan.

* **In-memory cache**: Add `statsCache` and `rateLimitCache` to store stats and rate limit data in memory.
* **Initialize stats**: Cache stats in memory to avoid repeated KV reads in the `initializeStats` function.
* **Stats middleware**: Batch updates to the stats and write them to the KV store periodically instead of on every request.
* **Rate limiting middleware**: Cache rate limit data in memory to avoid repeated KV reads and writes in the `checkRateLimit` function. Use a single KV read and write operation per request.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arcestia/domainchecker/pull/2?shareId=4c92ff8f-19cd-4d0a-a0d9-f73a43528f26).

## Summary by Sourcery

New Features:
- Implement in-memory caching for rate limiting and global statistics.